### PR TITLE
Remove not exist types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,7 @@
     "types": [
       "node",
       "jest",
-      "pify",
-      "./tests/typings/steps"
+      "pify"
     ],
     "esModuleInterop": true,
     "lib": [


### PR DESCRIPTION
Remove not exist types. This was added because of codeceptjs.
We don't need it now.

See also
  - https://codecept.io/commands#typescript-definitions